### PR TITLE
protect unit-threaded import

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -19,4 +19,5 @@ configuration "unittest" {
     dependency "unit-threaded" version="~>0.7.0"
     preBuildCommands "dub run unit-threaded -c gen_ut_main -- -f bin/ut.d"
     mainSourceFile "bin/ut.d"
+    versions "Test_nanomsg_wrapper"
 }

--- a/source/nanomsg/wrap.d
+++ b/source/nanomsg/wrap.d
@@ -18,7 +18,7 @@ module nanomsg.wrap;
 import nanomsg.bindings;
 public import std.typecons: Yes, No; // to facilitate using send, receive
 
-version(unittest)
+version(Test_nanomsg_wrapper)
     import unit_threaded;
 else
     enum HiddenTest;


### PR DESCRIPTION
otherwise dependent unittest builds have to depend on unit-threaded.