### PR TITLE
In doc generation, pass --case-insensitive-filenames and correct cleanup

### DIFF
--- a/makedocs.sh
+++ b/makedocs.sh
@@ -5,30 +5,29 @@ set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_DIR=$SCRIPT_DIR
 SOURCE_DIR=${PROJECT_DIR}/source/nanomsg
+SKELETON="${PROJECT_DIR}"/.skeleton.html
+DOCS_DIR="${PROJECT_DIR}"/docs
 
 echo Generating documentation for "${PROJECT_DIR}" into directory docs ...
 
-mkdir -p docs
+TMP_DIR=$(mktemp -d)
+delete_TMP_DIR() {
+  echo "Cleaning up temporary directory ${TMP_DIR} ..."
+  rm -rf "${TMP_DIR}"
+}
+trap 'delete_TMP_DIR' ERR
+git clone https://github.com/adamdruppe/adrdox "${TMP_DIR}"/adrdox
 
-[ -e tmp ] && rm -rf tmp
-mkdir tmp
-cd tmp
-git clone https://github.com/adamdruppe/adrdox
-cp "${PROJECT_DIR}"/.skeleton.html adrdox/skeleton.html
-mkdir -p "${PROJECT_DIR}"/docs/examples
+make -C "${TMP_DIR}"/adrdox
 
-cd adrdox
-make
+rm -rf "${DOCS_DIR}"
+mkdir -p "${DOCS_DIR}"/examples
 
-./doc2 --case-insensitive-filenames -i "${SOURCE_DIR}"
-mv generated-docs/* "${PROJECT_DIR}"/docs
+DOC2="${TMP_DIR}"/adrdox/doc2
+"${DOC2}" --case-insensitive-filenames -s "${SKELETON}" -i "${SOURCE_DIR}" -o "${DOCS_DIR}"
+"${DOC2}" --case-insensitive-filenames -s "${SKELETON}" -i "${PROJECT_DIR}"/examples -o "${DOCS_DIR}"/examples
+cp "${DOCS_DIR}"/nanomsg.html "${DOCS_DIR}"/index.html
 
-./doc2 --case-insensitive-filenames -i "${PROJECT_DIR}"/examples
-mv generated-docs/* "${PROJECT_DIR}"/docs/examples
-
-cp "${PROJECT_DIR}"/docs/nanomsg.html "${PROJECT_DIR}"/docs/index.html
-cd "${PROJECT_DIR}"
-
-rm -rf tmp
+delete_TMP_DIR
 
 echo Generation of documentation for "${PROJECT_DIR}" succeeded

--- a/makedocs.sh
+++ b/makedocs.sh
@@ -5,21 +5,30 @@ set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_DIR=$SCRIPT_DIR
 SOURCE_DIR=${PROJECT_DIR}/source/nanomsg
-echo generating documents for "${PROJECT_DIR}"
+
+echo Generating documentation for "${PROJECT_DIR}" into directory docs ...
+
 mkdir -p docs
-[ -e tmp ] && rm -r tmp
+
+[ -e tmp ] && rm -rf tmp
 mkdir tmp
 cd tmp
 git clone https://github.com/adamdruppe/adrdox
 cp "${PROJECT_DIR}"/.skeleton.html adrdox/skeleton.html
 mkdir -p "${PROJECT_DIR}"/docs/examples
+
 cd adrdox
 make
-./doc2 -i "${SOURCE_DIR}"
+
+./doc2 --case-insensitive-filenames -i "${SOURCE_DIR}"
 mv generated-docs/* "${PROJECT_DIR}"/docs
-./doc2 -i "${PROJECT_DIR}"/examples
+
+./doc2 --case-insensitive-filenames -i "${PROJECT_DIR}"/examples
 mv generated-docs/* "${PROJECT_DIR}"/docs/examples
+
 cp "${PROJECT_DIR}"/docs/nanomsg.html "${PROJECT_DIR}"/docs/index.html
 cd "${PROJECT_DIR}"
-rm -r tmp
-echo succeeded - docs generated
+
+rm -rf tmp
+
+echo Generation of documentation for "${PROJECT_DIR}" succeeded


### PR DESCRIPTION
Also uses `rm` flag `-f` in `makedocs.sh`.